### PR TITLE
Add SUBSCRIPTION_LINK merge_var

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "videlalvaro/php-amqplib": "v2.1.0",
         "DoSomething/messagebroker-phplib": "0.1.*",
         "mandrill/mandrill": "1.0.50",
-        "dosomething/mb-stat-tracker": "v0.0.3"
+        "dosomething/mb-stat-tracker": "v0.0.3",
+        "dosomething/mb-toolbox": "0.3.*"
     },
     "require-dev": {
       "phpunit/phpunit": "3.7.*"

--- a/mbc-user-event_anniversary.php
+++ b/mbc-user-event_anniversary.php
@@ -107,7 +107,13 @@ class MBC_UserEvent_Anniversary
           'FNAME' => $messagePayload['merge_vars']['FNAME'],
           'ANNIVERSARY' => $anniversary,
           'SUBSRIPTION_LINK' => $toolbox->subscriptionsLinkGenerator($messagePayload['email']),
-        )
+        ),
+        'global_merge_vars' => array(
+          0 => array(
+            'name' => 'MEMBER_COUNT',
+            'content' => $this->getMemberCount()
+          ),
+        ),
       );
       $messageCount--;
       $processedCount++;

--- a/mbc-user-event_anniversary.php
+++ b/mbc-user-event_anniversary.php
@@ -43,7 +43,14 @@ class MBC_UserEvent_Anniversary
    * Configuration settings
    */
   private $channel;
-  
+
+  /**
+   * Collection of helper methods
+   *
+   * @var object
+   */
+  private $toolbox;
+
   /**
    * A list of recipients to send messages to
    */
@@ -63,6 +70,7 @@ class MBC_UserEvent_Anniversary
     $this->channel = $this->messageBroker->connection->channel();
     $this->config = $config;
     $this->settings = $settings;
+    $this->toolbox = new MB_Toolbox($settings);
   }
 
   /**
@@ -98,6 +106,7 @@ class MBC_UserEvent_Anniversary
         'merge_vars' => array(
           'FNAME' => $messagePayload['merge_vars']['FNAME'],
           'ANNIVERSARY' => $anniversary,
+          'SUBSRIPTION_LINK' => $toolbox->subscriptionsLinkGenerator($messagePayload['email']),
         )
       );
       $messageCount--;
@@ -294,6 +303,8 @@ $config = array(
 );
 $settings = array(
   'stathat_ez_key' => getenv("STATHAT_EZKEY"),
+  'ds_drupal_api_host' => getenv('DS_DRUPAL_API_HOST'),
+  'ds_drupal_api_port' => getenv('DS_DRUPAL_API_PORT'),
 );
 
 echo '------- mbc-user-event_anniversary START: ' . date('D M j G:i:s T Y') . ' -------', "\n";

--- a/mbc-user-event_anniversary.php
+++ b/mbc-user-event_anniversary.php
@@ -13,8 +13,8 @@ use DoSomething\MBStatTracker\StatHat;
 
 // Load configuration settings common to the Message Broker system
 // symlinks in the project directory point to the actual location of the files
-require __DIR__ . '/mb-secure-config.inc';
-require __DIR__ . '/mb-config.inc';
+require_once __DIR__ . '/mb-secure-config.inc';
+require_once __DIR__ . '/mb-config.inc';
 
 class MBC_UserEvent_Anniversary
 {
@@ -144,7 +144,7 @@ class MBC_UserEvent_Anniversary
    */
   private function sendAnniversaryEmails() {
 
-    echo '------- MBC_UserEvent_Anniversary->sendAnniversaryEmails START - ' . date('D M j G:i:s T Y') . ' -------', "\n";
+    echo '------- MBC_UserEvent_Anniversary->sendAnniversaryEmails START - ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
 
     $to = array();
     $merge_vars = array();
@@ -204,11 +204,11 @@ class MBC_UserEvent_Anniversary
     // ack messages to remove them from the queue, trap errors
     foreach($mandrillResults as $resultCount => $resultDetails) {
       if ($resultDetails['status'] == 'invalid') {
-        echo '******* MBC_UserEvent_Anniversary->sendAnniversaryEmails Mandrill ERROR: "invalid" -> ' . $resultDetails['email'] . ' as Send-Template submission - ' . date('D M j G:i:s T Y') . ' *******', "\n";
+        echo '******* MBC_UserEvent_Anniversary->sendAnniversaryEmails Mandrill ERROR: "invalid" -> ' . $resultDetails['email'] . ' as Send-Template submission - ' . date('D M j G:i:s T Y') . ' *******', PHP_EOL;
         $statHat->addStatName('sendAnniversaryEmails_MandrillERROR_invalid');
       }
       elseif (!$resultDetails['status'] == 'sent') {
-        echo '******* MBC_UserEvent_Anniversary->sendAnniversaryEmails Mandrill ERROR: "Unknown" -> ' . print_r($resultDetails, TRUE) . ' as Send-Template submission - ' . date('D M j G:i:s T Y') . ' *******', "\n";
+        echo '******* MBC_UserEvent_Anniversary->sendAnniversaryEmails Mandrill ERROR: "Unknown" -> ' . print_r($resultDetails, TRUE) . ' as Send-Template submission - ' . date('D M j G:i:s T Y') . ' *******', PHP_EOL;
         $statHat->addStatName('sendAnniversaryEmails_MandrillERROR_unknown');
       }
       else {
@@ -220,7 +220,7 @@ class MBC_UserEvent_Anniversary
       $this->channel->basic_ack($delivery_tags[$resultCount]);
     }
 
-    echo '------- MBC_UserEvent_Anniversary->sendAnniversaryEmails END: ' . count($this->recipients) . ' messages sent as Mandrill Send-Template submission - ' . date('D M j G:i:s T Y') . ' -------', "\n";
+    echo '------- MBC_UserEvent_Anniversary->sendAnniversaryEmails END: ' . count($this->recipients) . ' messages sent as Mandrill Send-Template submission - ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
 
   }
 
@@ -261,10 +261,10 @@ $settings = array(
   'ds_drupal_api_port' => getenv('DS_DRUPAL_API_PORT'),
 );
 
-echo '------- mbc-user-event_anniversary START: ' . date('D M j G:i:s T Y') . ' -------', "\n";
+echo '------- mbc-user-event_anniversary START: ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
 
 // Kick Off
 $ua = new MBC_UserEvent_Anniversary($credentials, $config, $settings);
 $ua->consumeAnniversaryQueue();
 
-echo '------- mbp-user-event_anniversary END: ' . date('D M j G:i:s T Y') . ' -------', "\n";
+echo '------- mbp-user-event_anniversary END: ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;

--- a/mbc-user-event_anniversary.php
+++ b/mbc-user-event_anniversary.php
@@ -52,6 +52,13 @@ class MBC_UserEvent_Anniversary
   private $toolbox;
 
   /**
+   * The MEMBER_COUNT value from the DoSomething.org API via MB_Toolbox
+   *
+   * @var string
+   */
+  private $memberCount;
+
+  /**
    * A list of recipients to send messages to
    */
   private $recipients;
@@ -70,7 +77,9 @@ class MBC_UserEvent_Anniversary
     $this->channel = $this->messageBroker->connection->channel();
     $this->config = $config;
     $this->settings = $settings;
+
     $this->toolbox = new MB_Toolbox($settings);
+    $this->memberCount = $this->toolbox->getDSMemberCount();
   }
 
   /**
@@ -111,7 +120,7 @@ class MBC_UserEvent_Anniversary
         'global_merge_vars' => array(
           0 => array(
             'name' => 'MEMBER_COUNT',
-            'content' => $this->getMemberCount()
+            'content' => $this->memberCount,
           ),
         ),
       );
@@ -177,7 +186,7 @@ class MBC_UserEvent_Anniversary
       'global_merge_vars' => array(
         0 => array(
           'name' => 'MEMBER_COUNT',
-          'content' => $this->getMemberCount()
+          'content' => $this->memberCount,
         ),
       ),
       'tags' => array('user-event', 'anniversary'),
@@ -213,67 +222,6 @@ class MBC_UserEvent_Anniversary
 
     echo '------- MBC_UserEvent_Anniversary->sendAnniversaryEmails END: ' . count($this->recipients) . ' messages sent as Mandrill Send-Template submission - ' . date('D M j G:i:s T Y') . ' -------', "\n";
 
-  }
-
-  /**
-   * Gather current member count via Drupal end point.
-   * https://github.com/DoSomething/dosomething/wiki/API#get-member-count
-   *
-   *  POST https://beta.dosomething.org/api/v1/users/get_member_count
-   *
-   * @return string $memberCountFormatted
-   *   The string supplied byt the Drupal endpoint /get_member_count.
-   */
-  private function getMemberCount() {
-
-    $curlUrl = getenv('DS_DRUPAL_API_HOST');
-    $port = getenv('DS_DRUPAL_API_PORT');
-    if ($port != 0) {
-      $curlUrl .= ':' . $port;
-    }
-    $curlUrl .= '/api/v1/users/get_member_count';
-
-    // $post value sent in cURL call intentionally empty due to the endpoint
-    // expecting POST rather than GET where there's no POST values expected.
-    $post = array();
-
-    $result = $this->curlPOST($curlUrl, $post);
-    if (isset($result->readable)) {
-      $memberCountFormatted = $result->readable;
-    }
-    else {
-      $memberCountFormatted = NULL;
-    }
-    return $memberCountFormatted;
-
-  }
-
-  /**
-   * cURL POSTs
-   *
-   * @return object $result
-   *   The results retruned from the cURL call.
-   */
-  private function curlPOST($curlUrl, $post) {
-
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $curlUrl);
-    curl_setopt($ch, CURLOPT_POST, 1);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($post));
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_HTTPHEADER,
-      array(
-        'Content-type: application/json',
-        'Accept: application/json'
-      )
-    );
-    curl_setopt($ch,CURLOPT_CONNECTTIMEOUT, 3);
-    curl_setopt($ch,CURLOPT_TIMEOUT, 20);
-    $jsonResult = curl_exec($ch);
-    $result = json_decode($jsonResult);
-    curl_close($ch);
-
-    return $result;
   }
 
 }

--- a/mbc-user-event_anniversary.php
+++ b/mbc-user-event_anniversary.php
@@ -116,13 +116,7 @@ class MBC_UserEvent_Anniversary
           'FNAME' => $messagePayload['merge_vars']['FNAME'],
           'ANNIVERSARY' => $anniversary,
           'SUBSRIPTION_LINK' => $toolbox->subscriptionsLinkGenerator($messagePayload['email']),
-        ),
-        'global_merge_vars' => array(
-          0 => array(
-            'name' => 'MEMBER_COUNT',
-            'content' => $this->memberCount,
-          ),
-        ),
+        )
       );
       $messageCount--;
       $processedCount++;
@@ -170,10 +164,21 @@ class MBC_UserEvent_Anniversary
             'name' => 'UID',
             'content' => $recipient['uid'],
           ),
+          3 => array(
+            'name' => 'SUBSRIPTION_LINK',
+            'content' => $recipient['merge_vars']['SUBSRIPTION_LINK'],
+          )
         ),
       );
       $delivery_tags[] = $recipient['delivery_tag'];
     }
+
+    $globalMergeVars = array(
+      0 => array(
+        'name' => 'MEMBER_COUNT',
+        'content' => $this->memberCount,
+      ),
+    );
 
     $templateName = 'mb-userevent-anniversary-v2';
     $templateContent = array();
@@ -183,12 +188,7 @@ class MBC_UserEvent_Anniversary
       'subject' => 'Happy Anniversary from DoSomething.org',
       'to' => $to,
       'merge_vars' => $merge_vars,
-      'global_merge_vars' => array(
-        0 => array(
-          'name' => 'MEMBER_COUNT',
-          'content' => $this->memberCount,
-        ),
-      ),
+      'global_merge_vars' => $globalMergeVars,
       'tags' => array('user-event', 'anniversary'),
     );
 

--- a/mbc-user-event_anniversary.php
+++ b/mbc-user-event_anniversary.php
@@ -115,7 +115,7 @@ class MBC_UserEvent_Anniversary
         'merge_vars' => array(
           'FNAME' => $messagePayload['merge_vars']['FNAME'],
           'ANNIVERSARY' => $anniversary,
-          'SUBSRIPTION_LINK' => $toolbox->subscriptionsLinkGenerator($messagePayload['email']),
+          'SUBSRIPTIONS_LINK' => $toolbox->subscriptionsLinkGenerator($messagePayload['email']),
         )
       );
       $messageCount--;
@@ -165,8 +165,8 @@ class MBC_UserEvent_Anniversary
             'content' => $recipient['uid'],
           ),
           3 => array(
-            'name' => 'SUBSRIPTION_LINK',
-            'content' => $recipient['merge_vars']['SUBSRIPTION_LINK'],
+            'name' => 'SUBSRIPTIONS_LINK',
+            'content' => $recipient['merge_vars']['SUBSRIPTIONS_LINK'],
           )
         ),
       );

--- a/mbc-user-event_birthday.php
+++ b/mbc-user-event_birthday.php
@@ -103,7 +103,7 @@ class MBC_UserEvent_Birthday
         'delivery_tag' => $messageDetails->delivery_info['delivery_tag'],
         'merge_vars' => array(
           'FNAME' => $messagePayload['merge_vars']['FNAME'],
-          'SUBSRIPTION_LINK' => $toolbox->subscriptionsLinkGenerator($messagePayload['email']),
+          'SUBSRIPTIONS_LINK' => $toolbox->subscriptionsLinkGenerator($messagePayload['email']),
         )
       );
       $messageCount--;
@@ -146,8 +146,8 @@ class MBC_UserEvent_Birthday
             'content' => $recipient['merge_vars']['FNAME'],
           ),
           1 => array(
-            'name' => 'SUBSRIPTION_LINK',
-            'content' => $recipient['merge_vars']['SUBSRIPTION_LINK'],
+            'name' => 'SUBSRIPTIONS_LINK',
+            'content' => $recipient['merge_vars']['SUBSRIPTIONS_LINK'],
           ),
         ),
       );

--- a/mbc-user-event_birthday.php
+++ b/mbc-user-event_birthday.php
@@ -13,8 +13,8 @@ use DoSomething\MBStatTracker\StatHat;
 
 // Load configuration settings common to the Message Broker system
 // symlinks in the project directory point to the actual location of the files
-require __DIR__ . '/mb-secure-config.inc';
-require __DIR__ . '/mb-config.inc';
+require_once __DIR__ . '/mb-secure-config.inc';
+require_once __DIR__ . '/mb-config.inc';
 
 class MBC_UserEvent_Birthday
 {
@@ -127,7 +127,7 @@ class MBC_UserEvent_Birthday
    */
   private function sendBirthdayEmails() {
 
-    echo '------- MBC_UserEvent_Birthday->sendBirthdayEmails START - ' . date('D M j G:i:s T Y') . ' -------', "\n";
+    echo '------- MBC_UserEvent_Birthday->sendBirthdayEmails START - ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
 
     $to = array();
     $merge_vars = array();
@@ -183,11 +183,11 @@ class MBC_UserEvent_Birthday
     // ack messages to remove them from the queue, trap errors
     foreach($mandrillResults as $resultCount => $resultDetails) {
       if ($resultDetails['status'] == 'invalid') {
-        echo '******* MBC_UserEvent_Birthday->sendBirthdayEmails Mandrill ERROR: "invalid" -> ' . $resultDetails['email'] . ' as Send-Template submission - ' . date('D M j G:i:s T Y') . ' *******', "\n";
+        echo '******* MBC_UserEvent_Birthday->sendBirthdayEmails Mandrill ERROR: "invalid" -> ' . $resultDetails['email'] . ' as Send-Template submission - ' . date('D M j G:i:s T Y') . ' *******', PHP_EOL;
         $statHat->addStatName('sendBirthdayEmails_MandrillERROR_invalid');
       }
       elseif (!$resultDetails['status'] == 'sent' && !$resultDetails['status'] == 'queued') {
-        echo '******* MBC_UserEvent_Birthday->sendBirthdayEmails Mandrill ERROR: "Unknown" -> ' . print_r($resultDetails, TRUE) . ' as Send-Template submission - ' . date('D M j G:i:s T Y') . ' *******', "\n";
+        echo '******* MBC_UserEvent_Birthday->sendBirthdayEmails Mandrill ERROR: "Unknown" -> ' . print_r($resultDetails, TRUE) . ' as Send-Template submission - ' . date('D M j G:i:s T Y') . ' *******', PHP_EOL;
         $statHat->addStatName('sendBirthdayEmails_MandrillERROR_unknown');
       }
       else {
@@ -199,7 +199,7 @@ class MBC_UserEvent_Birthday
       $this->channel->basic_ack($delivery_tags[$resultCount]);
     }
 
-    echo '------- MBC_UserEvent_Birthday->sendBirthdayEmails END: ' . (count($this->recipients) - 1) . ' messages sent as Mandrill Send-Template submission - ' . date('D M j G:i:s T Y') . ' -------', "\n";
+    echo '------- MBC_UserEvent_Birthday->sendBirthdayEmails END: ' . (count($this->recipients) - 1) . ' messages sent as Mandrill Send-Template submission - ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
 
   }
 
@@ -240,10 +240,10 @@ $settings = array(
   'ds_drupal_api_port' => getenv('DS_DRUPAL_API_PORT'),
 );
 
-echo '------- mbc-user-event_birthday START: ' . date('D M j G:i:s T Y') . ' -------', "\n";
+echo '------- mbc-user-event_birthday START: ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;
 
 // Kick Off
 $ub = new MBC_UserEvent_Birthday($credentials, $config, $settings);
 $ub->consumeBirthdayQueue();
 
-echo '------- mbp-user-event_birthday END: ' . date('D M j G:i:s T Y') . ' -------', "\n";
+echo '------- mbp-user-event_birthday END: ' . date('D M j G:i:s T Y') . ' -------', PHP_EOL;

--- a/mbc-user-event_birthday.php
+++ b/mbc-user-event_birthday.php
@@ -42,6 +42,13 @@ class MBC_UserEvent_Birthday
   private $channel;
 
   /**
+   * Collection of helper methods
+   *
+   * @var object
+   */
+  private $toolbox;
+
+  /**
    * A list of recipients to send messages to
    */
   private $recipients;
@@ -60,6 +67,7 @@ class MBC_UserEvent_Birthday
     $this->channel = $this->messageBroker->connection->channel();
     $this->config = $config;
     $this->settings = $settings;
+    $this->toolbox = new MB_Toolbox($settings);
   }
 
   /**
@@ -86,6 +94,7 @@ class MBC_UserEvent_Birthday
         'delivery_tag' => $messageDetails->delivery_info['delivery_tag'],
         'merge_vars' => array(
           'FNAME' => $messagePayload['merge_vars']['FNAME'],
+          'SUBSRIPTION_LINK' => $toolbox->subscriptionsLinkGenerator($messagePayload['email']),
         ),
         'global_merge_vars' => array(
           0 => array(
@@ -274,6 +283,8 @@ $config = array(
 );
 $settings = array(
   'stathat_ez_key' => getenv("STATHAT_EZKEY"),
+  'ds_drupal_api_host' => getenv('DS_DRUPAL_API_HOST'),
+  'ds_drupal_api_port' => getenv('DS_DRUPAL_API_PORT'),
 );
 
 echo '------- mbc-user-event_birthday START: ' . date('D M j G:i:s T Y') . ' -------', "\n";


### PR DESCRIPTION
- Add \*|subscriptions_link|\* to digest email messages to allow users to change their subscription settings. Send the `merge_var` value as
```
`http://subscriptions.dosomething.org?email=test@test&key=77c0106198897e478b37e01e0a16a70d
```
The markup in the message needs to be:
```
<a href=""*|subscriptions_link|*" target="_NEW">Unsubscribe></a>
```

- Add \*|MEMBER_COUNT|\* `merge_var` to anniversary user event message
- Move to MB_Toolbox for MEMBER_COUNT lookup.
- Remove internal cURL based method for MEMBER_COUNT lookup.

**Related**:
https://github.com/DoSomething/mb-toolbox/issues/24
https://github.com/DoSomething/mbc-user-subscriptions/issues/2
https://github.com/DoSomething/mbc-digest-email/issues/28

Fixes #13 